### PR TITLE
Remove incorrect dependency on "crypto" NPM module

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
     "type": "git",
     "url": "https://github.com/jaysvoboda/nodejs-aes256.git"
   },
-  "dependencies": {
-	"crypto": "0.0.3"
-  },
   "keywords": [
     "aes",
     "aes256",


### PR DESCRIPTION
The Node.js core "crypto" module is what is actually getting used since the [NPM module named "crypto"](https://www.npmjs.com/package/crypto) doesn't even have a main driver module specified, nor does it support AES ([source](https://github.com/Gozala/crypto)).