### PR TITLE
detect failures by switching to GCM

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,3 @@ For decryption, simply provide the shared key and ciphertext.
 ## Notes
 
 * This has only been tested with strings for the shared key and plaintext
-* It does not detect if decryption has failed

--- a/nodejs-aes256.js
+++ b/nodejs-aes256.js
@@ -1,6 +1,6 @@
 var aes256 = {},
     crypto = require('crypto'),
-    algorithm = 'aes-256-ctr';
+    algorithm = 'aes-256-gcm';
 
 aes256.encrypt = function (key, data) {
     var sha256 = crypto.createHash('sha256');
@@ -10,7 +10,7 @@ aes256.encrypt = function (key, data) {
         plaintext = new Buffer(data),
         cipher = crypto.createCipheriv(algorithm, sha256.digest(), iv),
         ciphertext = cipher.update(plaintext);
-    ciphertext = Buffer.concat([iv, ciphertext, cipher.final()]);
+    ciphertext = Buffer.concat([iv, ciphertext, cipher.final(), cipher.getAuthTag()]);
 
     return ciphertext.toString('base64');
 };
@@ -21,9 +21,13 @@ aes256.decrypt = function (key, data) {
 
     var input = new Buffer(data, 'base64'),
         iv = input.slice(0, 16),
-        ciphertext = input.slice(16),
-        decipher = crypto.createDecipheriv(algorithm, sha256.digest(), iv),
-        plaintext = decipher.update(ciphertext);
+        ciphertext = input.slice(16, -16),
+        authTag = input.slice(-16),
+        decipher = crypto.createDecipheriv(algorithm, sha256.digest(), iv);
+
+    decipher.setAuthTag(authTag);
+
+    var plaintext = decipher.update(ciphertext);
     plaintext += decipher.final();
 
     return plaintext;


### PR DESCRIPTION
By switching to the GCM mode of operation this will throw an error if the anything is wrong (cipher text or password)